### PR TITLE
Enhance Nfc methods

### DIFF
--- a/cieidsdk/src/main/java/it/ipzs/cieidsdk/common/CieIDSdk.kt
+++ b/cieidsdk/src/main/java/it/ipzs/cieidsdk/common/CieIDSdk.kt
@@ -25,7 +25,6 @@ import it.ipzs.cieidsdk.url.DeepLinkInfo
 import it.ipzs.cieidsdk.util.CieIDSdkLogger
 import okhttp3.ResponseBody
 import retrofit2.Response
-import java.lang.NullPointerException
 import java.net.SocketTimeoutException
 import java.net.UnknownHostException
 import javax.net.ssl.SSLProtocolException


### PR DESCRIPTION
Questa PR vuole migliorare i metodi che interagiscono con l'NFC
In particolare _l'nfcAdapter_ viene istanziato solo nella chiamata [start](https://github.com/teamdigitale/io-cie-android-sdk/blob/04f84721e2794a41c1c175df382913b817624596/cieidsdk/src/main/java/it/ipzs/cieidsdk/common/CieIDSdk.kt#L174)

Quindi nel caso in cui l'NFC è spento l'_adpter_ sarà nullo. Per controllare se l'nfc è abilitato occorre richiamare prima il metodo **start** affinche il risultato sia aggiornato. 

### esempio
- **start** dell'sdk
- **isNFCEnabled** -> false
- l'utente lo abilita
- **isNFCEnabled** -> false (perchè bisogna richiamare la start)

Viene introdotto il metodo privato **getNfcAdapter** all'interno del metodo **isNFCEnabled** che controlla se l'adpter è nullo e nel caso prova a recuperarlo di nuovo 

Inoltre sono stato cambiati i nomi di alcuni metodi rendondoli più coerenti alla funzione espressa