### PR TITLE
Change isoDep timeout from default (300ms) to 2s

### DIFF
--- a/cieidsdk/src/main/java/it/ipzs/cieidsdk/common/CieIDSdk.kt
+++ b/cieidsdk/src/main/java/it/ipzs/cieidsdk/common/CieIDSdk.kt
@@ -81,6 +81,7 @@ interface Callback {
 
 object CieIDSdk : NfcAdapter.ReaderCallback {
 
+	val isoDepTimeout: Int = 2000
 
     @SuppressLint("CheckResult")
     fun call(certificate: ByteArray) {
@@ -143,6 +144,7 @@ object CieIDSdk : NfcAdapter.ReaderCallback {
         try {
             callback?.onEvent(Event(Event.EventValue.ON_TAG_DISCOVERED))
             val isoDep = IsoDep.get(tag)
+            isoDep.timeout = isoDepTimeout
             isoDep.connect()
             ias = Ias(isoDep)
             ias!!.getIdServizi()


### PR DESCRIPTION
Questa PR vuole evitare che il superamento del timeout di default (300ms) durante la trasmissione di dati all'nfc genere una eccezione (_TagLostException_)

Per prevenire questo comportamento viene settato un timeout di 2 secondi ogni volta che un oggetto di tipo _**IsoDep**_ viene creato