### PR TITLE
[#168954275] Increase transceive timeout

### DIFF
--- a/cieidsdk/src/main/java/it/ipzs/cieidsdk/common/CieIDSdk.kt
+++ b/cieidsdk/src/main/java/it/ipzs/cieidsdk/common/CieIDSdk.kt
@@ -104,7 +104,9 @@ object CieIDSdk : NfcAdapter.ReaderCallback {
     internal var ias: Ias? = null
     var enableLog: Boolean = false
     var pin: String = ""
-    private const val isoDepTimeout: Int = 4000
+    // the timeout of transceive(byte[]) in milliseconds (https://developer.android.com/reference/android/nfc/tech/IsoDep#setTimeout(int))
+    // a longer timeout may be useful when performing transactions that require a long processing time on the tag such as key generation.
+    private const val isoDepTimeout: Int = 10000
 
 
     @SuppressLint("CheckResult")


### PR DESCRIPTION
This PR increases the transceive timeout from 2 second to 10 seconds

>Setting a longer timeout may be useful when performing transactions that require a long processing time on the tag such as key generation.

https://developer.android.com/reference/android/nfc/tech/IsoDep#setTimeout(int)