### PR TITLE
[#169129603] Add Api level check

### DIFF
--- a/cieidsdk/index.d.ts
+++ b/cieidsdk/index.d.ts
@@ -19,6 +19,8 @@ declare module "react-native-cie" {
     attempts: number;
   };
   interface CieManager {
+    // check if the OS support CIE autentication
+    hasApiLevelSupport(): Promise<boolean>;
     // check if the device has NFC feature
     hasNFCFeature(): Promise<boolean>;
     // check if NFC is enabled

--- a/cieidsdk/index.js
+++ b/cieidsdk/index.js
@@ -128,6 +128,22 @@ class CieManager {
   };
 
   /**
+    return a Promise will be resolved with true if the current OS supports the authentication. 
+    This method is due because with API level < 23 a security exception is raised
+    read more here - https://github.com/teamdigitale/io-cie-android-sdk/issues/10
+   */
+  hasApiLevelSupport = () => {
+    if (Platform.OS === "ios") {
+      return Promise.reject("not implemented");
+    }
+    return new Promise(resolve => {
+      NativeCie.hasApiLevelSupport(result => {
+        resolve(result);
+      });
+    });
+  };
+
+  /**
    * Check if the hardware module nfc is installed (only for Android devices)
    */
   hasNFCFeature = () => {

--- a/cieidsdk/src/main/java/it/ipzs/cieidsdk/common/CieIDSdk.kt
+++ b/cieidsdk/src/main/java/it/ipzs/cieidsdk/common/CieIDSdk.kt
@@ -11,6 +11,7 @@ import android.nfc.NfcManager
 import android.nfc.Tag
 import android.nfc.TagLostException
 import android.nfc.tech.IsoDep
+import android.os.Build
 import android.provider.Settings
 import io.reactivex.android.schedulers.AndroidSchedulers
 import io.reactivex.observers.DisposableSingleObserver
@@ -269,6 +270,15 @@ object CieIDSdk : NfcAdapter.ReaderCallback {
      */
     fun openNFCSettings(activity: Activity) {
         activity.startActivity(Intent(Settings.ACTION_NFC_SETTINGS))
+    }
+
+    /**
+    return true if the current OS supports the authentication. This method is due because with API level < 23 a security exception is raised
+    read more here - https://github.com/teamdigitale/io-cie-android-sdk/issues/10
+     */
+    fun hasApiLevelSupport() : Boolean {
+        // M is for Marshmallow! -> Api level 23
+        return Build.VERSION.SDK_INT >= Build.VERSION_CODES.M
     }
 
 

--- a/cieidsdk/src/main/java/it/ipzs/cieidsdk/native_bridge/CieModule.kt
+++ b/cieidsdk/src/main/java/it/ipzs/cieidsdk/native_bridge/CieModule.kt
@@ -1,4 +1,3 @@
-
 package it.ipzs.cieidsdk.native_bridge
 
 import com.facebook.react.bridge.*
@@ -9,12 +8,11 @@ import com.facebook.react.modules.core.RCTNativeAppEventEmitter
 import com.facebook.react.bridge.Arguments.createMap
 
 
+class CieModule(reactContext: ReactApplicationContext) : ReactContextBaseJavaModule(reactContext),
+    Callback {
 
 
-class CieModule(reactContext: ReactApplicationContext) : ReactContextBaseJavaModule(reactContext), Callback {
-
-
-    private var cieInvalidPinAttempts : Int = 0
+    private var cieInvalidPinAttempts: Int = 0
 
     /**
      * onSuccess is called when the CIE authentication is successfully completed.
@@ -37,22 +35,21 @@ class CieModule(reactContext: ReactApplicationContext) : ReactContextBaseJavaMod
      */
     override fun onEvent(event: Event) {
         cieInvalidPinAttempts = event.attempts;
-        this.sendEvent(eventChannel,event.toString())
+        this.sendEvent(eventChannel, event.toString())
     }
 
     override fun getName(): String {
         return "NativeCieModule"
     }
 
-    private fun getWritableMap(eventValue: String) : WritableMap{
+    private fun getWritableMap(eventValue: String): WritableMap {
         val writableMap = createMap()
         writableMap.putString("event", eventValue)
         writableMap.putInt("attempts", cieInvalidPinAttempts)
         return writableMap
     }
 
-    private fun sendEvent(channel : String, eventValue : String)
-     {
+    private fun sendEvent(channel: String, eventValue: String) {
         reactApplicationContext
             .getJSModule(RCTNativeAppEventEmitter::class.java)
             .emit(channel, getWritableMap(eventValue))
@@ -60,12 +57,12 @@ class CieModule(reactContext: ReactApplicationContext) : ReactContextBaseJavaMod
 
 
     @ReactMethod
-    fun start(callback: com.facebook.react.bridge.Callback){
+    fun start(callback: com.facebook.react.bridge.Callback) {
         try {
             CieIDSdk.start(getCurrentActivity()!!, this)
             callback.invoke(null, null)
         } catch (e: RuntimeException) {
-            callback.invoke(e.message,null)
+            callback.invoke(e.message, null)
         }
     }
 
@@ -80,12 +77,11 @@ class CieModule(reactContext: ReactApplicationContext) : ReactContextBaseJavaMod
     }
 
     @ReactMethod
-    fun setPin(pin: String,callback: com.facebook.react.bridge.Callback) {
-        try{
+    fun setPin(pin: String, callback: com.facebook.react.bridge.Callback) {
+        try {
             CieIDSdk.pin = pin
             callback.invoke()
-        }
-        catch(e: IllegalArgumentException){
+        } catch (e: IllegalArgumentException) {
             callback.invoke(e.message)
         }
     }
@@ -99,9 +95,9 @@ class CieModule(reactContext: ReactApplicationContext) : ReactContextBaseJavaMod
     fun startListeningNFC(callback: com.facebook.react.bridge.Callback) {
         try {
             CieIDSdk.startNFCListening(getCurrentActivity()!!)
-            callback.invoke(null,null)
+            callback.invoke(null, null)
         } catch (e: RuntimeException) {
-            callback.invoke(e.message,null)
+            callback.invoke(e.message, null)
         }
     }
 
@@ -111,7 +107,7 @@ class CieModule(reactContext: ReactApplicationContext) : ReactContextBaseJavaMod
             CieIDSdk.stopNFCListening(getCurrentActivity()!!)
             callback.invoke(null, null)
         } catch (e: RuntimeException) {
-            callback.invoke(e.message,null)
+            callback.invoke(e.message, null)
         }
     }
 
@@ -131,4 +127,10 @@ class CieModule(reactContext: ReactApplicationContext) : ReactContextBaseJavaMod
             callback.invoke();
         }
     }
+
+    @ReactMethod
+    fun hasApiLevelSupport(callback: com.facebook.react.bridge.Callback) {
+        callback.invoke(CieIDSdk.hasApiLevelSupport())
+    }
+
 }

--- a/cieidsdk/src/main/java/tests/test.apilevel.kt
+++ b/cieidsdk/src/main/java/tests/test.apilevel.kt
@@ -1,0 +1,51 @@
+package tests
+
+import io.kotlintest.specs.FreeSpec
+import io.kotlintest.specs.StringSpec
+import java.lang.reflect.Field
+import java.lang.reflect.Modifier
+import android.os.Build
+import io.kotlintest.matchers.shouldBe
+import it.ipzs.cieidsdk.common.CieIDSdk
+
+
+@Throws(Exception::class)
+fun setFinalStatic(field: Field, newValue: Any) {
+    field.setAccessible(true)
+
+    val modifiersField = Field::class.java!!.getDeclaredField("modifiers")
+    modifiersField.setAccessible(true)
+    modifiersField.setInt(field, field.getModifiers() and Modifier.FINAL.inv())
+
+    field.set(null, newValue)
+}
+
+class ApiLevel : FreeSpec({
+
+    // arrange
+    setFinalStatic(Build.VERSION::class.java.getField("SDK_INT"), 123)
+    // act
+    val apiLevel = CieIDSdk.hasApiLevelSupport()
+    //assert
+    "should api 123 level be supported"{
+        apiLevel shouldBe true
+    }
+
+    // arrange
+    setFinalStatic(Build.VERSION::class.java.getField("SDK_INT"), 23)
+    // act
+    val apiLevel23 = CieIDSdk.hasApiLevelSupport()
+    //assert
+    "should api 23 level be supported"{
+        apiLevel23 shouldBe true
+    }
+
+    // arrange
+    setFinalStatic(Build.VERSION::class.java.getField("SDK_INT"), 22)
+    // act
+    val apiLevel22 = CieIDSdk.hasApiLevelSupport()
+    //assert
+    "should api 22 level not be supported"{
+        apiLevel22 shouldBe false
+    }
+})


### PR DESCRIPTION
This PR add a method that return true if the current OS supports the authentication. 
This method is due because with API level < 23 a security exception is raised

read more here - https://github.com/teamdigitale/io-cie-android-sdk/issues/10