### PR TITLE
[#169129603] Add React method - isCIEAuthenticationSupported

### DIFF
--- a/cieidsdk/index.d.ts
+++ b/cieidsdk/index.d.ts
@@ -19,27 +19,61 @@ declare module "react-native-cie" {
     attempts: number;
   };
   interface CieManager {
-    // check if the OS support CIE autentication
+    /**
+     * check if the OS support CIE autentication
+     */
     hasApiLevelSupport(): Promise<boolean>;
-    // check if the device has NFC feature
+    /**
+     * check if the device has NFC feature
+     */
     hasNFCFeature(): Promise<boolean>;
-    // check if NFC is enabled
+    /**
+     * check if the device running the code supports CIE authentication
+     */
+
+    isCIEAuthenticationSupported(): Promise<boolean>;
+    /**
+     * check if NFC is enabled
+     */
+
     isNFCEnabled(): Promise<boolean>;
-    // register a callback to receive all Event raised while reading/writing CIE
+    /**
+     * register a callback to receive all Event raised while reading/writing CIE
+     */
+
     onEvent(callback: (event: Event) => void): void;
-    // register a callback to receive errors occured while reading/writing CIE
+    /**
+     * opens OS Settings on NFC section
+     */
+
+    openNFCSettings(): Promise<void>;
+    /**
+     * register a callback to receive errors occured while reading/writing CIE
+     */
+
     onError(callback: (error: Error) => void): void;
-    // register a callback to receive the success event containing the consent form url
+    /**
+     * register a callback to receive the success event containing the consent form url
+     */
+
     onSuccess(callback: (url: string) => void): void;
     setAuthenticationUrl(url: string): void;
-    // set the CIE pin. It has to be a 8 length string of 8 digits
+    /**
+     * set the CIE pin. It has to be a 8 length string of 8 digits
+     */
     setPin(pin: string): Promise<void>;
     start(): Promise<void>;
-    // command CIE SDK to start reading/writing CIE CARD
+    /**
+     * command CIE SDK to start reading/writing CIE CARD
+     */
     startListeningNFC(): Promise<void>;
-    // command CIE SDK to stop reading/writing CIE CARD
+    /**
+     * command CIE SDK to stop reading/writing CIE CARD
+     */
     stopListeningNFC(): Promise<void>;
-    // Remove all events callbacks: onEvent / onError / onSuccess
+    /**
+     * Remove all events callbacks: onEvent / onError / onSuccess
+     */
     removeAllListeners(): void;
   }
 

--- a/cieidsdk/index.js
+++ b/cieidsdk/index.js
@@ -112,6 +112,16 @@ class CieManager {
     });
   };
 
+  isCIEAuthenticationSupported = async () => {
+    try {
+      const hasNFCFeature = await this.hasNFCFeature();
+      const hasApiLevelSupport = await this.hasApiLevelSupport();
+      return Promise.resolve(hasNFCFeature && hasApiLevelSupport);
+    } catch {
+      return Promise.resolve(false);
+    }
+  };
+
   /**
    * Return true if the nfc is enabled, on the device in Settings screen
    * is possible enable or disable it.

--- a/cieidsdk/src/main/java/it/ipzs/cieidsdk/native_bridge/CieModule.kt
+++ b/cieidsdk/src/main/java/it/ipzs/cieidsdk/native_bridge/CieModule.kt
@@ -36,7 +36,7 @@ class CieModule(reactContext: ReactApplicationContext) : ReactContextBaseJavaMod
      * onEvent is called if an event occurs
      */
     override fun onEvent(event: Event) {
-        cieInvalidPinAttempts = event.attempts!!
+        cieInvalidPinAttempts = event.attempts ?: cieInvalidPinAttempts
         this.sendEvent(eventChannel,event.toString())
     }
 


### PR DESCRIPTION
This PR adds a React method **isCIEAuthenticationSupported** to know if running device supports the CIE authentication.

A fix is also added about null check on cie attempts.
Add **openNFCSettings** React method to open NFC settings in the host OS