### PR TITLE
[IA-222] An unhandled exception causes crash

### DIFF
--- a/android/src/main/java/it/ipzs/cieidsdk/common/CieIDSdk.kt
+++ b/android/src/main/java/it/ipzs/cieidsdk/common/CieIDSdk.kt
@@ -76,6 +76,11 @@ object CieIDSdk : NfcAdapter.ReaderCallback {
             put(IdpService.generaCodice, "1")
         }
 
+        RxJavaPlugins.setErrorHandler { error -> run {
+            CieIDSdkLogger.log("error handled by RxJavaPlugins $error")
+            callback?.onError(error)
+        } }
+
         idpService.callIdp(mapValues).subscribeOn(Schedulers.io())
             .observeOn(AndroidSchedulers.mainThread())
             .subscribeWith(object :


### PR DESCRIPTION
This PR adds the handling of an exception that is causing crash in a specific condition
More details here
https://github.com/ReactiveX/RxJava/wiki/What's-different-in-2.0#error-handling

This fix is also proposed in the main SDK repo
https://github.com/italia/cieid-android-sdk/pull/20

### before
https://user-images.githubusercontent.com/822471/134198888-16b2ee32-25fc-44c1-a93d-da12a65d2e91.mp4

### now
https://user-images.githubusercontent.com/822471/134198927-55b6f0d4-a0c2-4fc7-9765-210c75b301ae.mp4


