### PR TITLE
Change `maven` to `maven-publish`

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
-apply plugin: 'maven'
+apply plugin: 'maven-publish'
 
 android {
     compileSdkVersion 29


### PR DESCRIPTION
This pr updates the plugin from `maven` to `maven-publish` since is deprecated and not supported starting from Gradle 7.0.