### PR TITLE
[#IOPLT-764] chore: removes kotlin-android-extensions due to compatibility with rn 0.75

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,6 +1,5 @@
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
-apply plugin: 'kotlin-android-extensions'
 apply plugin: 'maven-publish'
 
 android {


### PR DESCRIPTION
Removes gradle plugin to let main app upgrade to react-native `0.75`