### PR TITLE
fix: [IOPID-2404] `javax.net.ssl.SSLHandshakeException` on different SDK provider

### DIFF
--- a/android/src/main/java/it/ipzs/cieidsdk/ciekeystore/CieProvider.kt
+++ b/android/src/main/java/it/ipzs/cieidsdk/ciekeystore/CieProvider.kt
@@ -3,14 +3,15 @@ package it.ipzs.cieidsdk.ciekeystore
 import java.security.Provider
 
 
-internal class CieProvider : Provider(CieProvider::class.java.simpleName, 1.0, "Provider per cie") {
+internal class CieProvider : Provider(PROVIDER_NAME, 1.0, "Provider per cie") {
 
     companion object {
-        const val PROVIDER = "CIE"
+      const val PROVIDER_NAME = "CieProvider"
+      const val KEYSTORE_TYPE = "CIE"
     }
 
     init {
-        put("KeyStore.$PROVIDER", CieKeyStore::class.java.name)
+        put("KeyStore.$KEYSTORE_TYPE", CieKeyStore::class.java.name)
         if (android.os.Build.VERSION.SDK_INT < android.os.Build.VERSION_CODES.Q) {
             put("Signature.NONEwithRSA", CieSignatureImpl.None::class.java.name)
         } else {

--- a/android/src/main/java/it/ipzs/cieidsdk/network/NetworkClient.kt
+++ b/android/src/main/java/it/ipzs/cieidsdk/network/NetworkClient.kt
@@ -35,7 +35,7 @@ internal class NetworkClient(
 
     private fun okhttpInitializer(): OkHttpClient {
 
-        Security.removeProvider(CieProvider.PROVIDER)
+        Security.removeProvider(CieProvider.PROVIDER_NAME)
         val cieProvider = CieProvider()
         Security.insertProviderAt(cieProvider, 1)
 
@@ -45,7 +45,7 @@ internal class NetworkClient(
             .readTimeout(15, TimeUnit.SECONDS)
             .writeTimeout(15, TimeUnit.SECONDS)
 
-        val cieKeyStore: KeyStore = KeyStore.getInstance(CieProvider.PROVIDER)
+        val cieKeyStore: KeyStore = KeyStore.getInstance(CieProvider.KEYSTORE_TYPE)
         cieKeyStore.load(ByteArrayInputStream(certificate), null)
 
         val kmf = KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm())


### PR DESCRIPTION
## Short description

This PR fixes the issue with the security provider removal, as detailed in the [analysis document](https://pagopa.atlassian.net/wiki/spaces/IAEI/pages/1966932047/Analisi+per+verifica+possibile+convivenza+tra+SDK+CIE+old+e+new).

## List of changes proposed in this pull request

- Corrected the removal of the security provider by referencing its exact name.

## How to test

1. Link the PR branch to io-app project.
2. Perform an EIC read process.
3. Verify that no regressions occur during the operation.
4. Confirm that the security provider is correctly handled and no unexpected removals happen.